### PR TITLE
transformers 4.29.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,8 +37,8 @@ requirements:
     - numpy
     - packaging
     # TODO: Working around osx bug importing two openmp variants.
-    - pytorch  # [not (osx and x86_64)]
-    - pytorch <1.12,>1.9  # [osx and x86_64]
+    - pytorch             # [not (osx and x86_64)]
+    - pytorch >1.9,<1.12  # [osx and x86_64]
     - pyyaml
     - regex !=2019.12.17
     - requests

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,7 @@ requirements:
     - datasets
     - importlib-metadata  # [py<38]
     - filelock
-    - huggingface_hub
+    - huggingface_hub >=0.14.1,<1.0
     - numpy
     - packaging
     - pytorch

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "transformers" %}
-{% set version = "4.24.0" %}
+{% set version = "4.29.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,11 +7,11 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 486f353a8e594002e48be0e2aba723d96eda839e63bfe274702a4b5eda85559b
+  sha256: ed9467661f459f1ce49461d83f18f3b36b6a37f306182dc2ba272935f3b93ebb
 
 build:
   skip: True  # [py<37]
-  number: 1
+  number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:
     - transformers-cli=transformers.commands.transformers_cli:main
@@ -24,16 +24,19 @@ requirements:
     - wheel
   run:
     - python
+    # datasets required for transformers-cli.
+    - datasets
     - importlib-metadata  # [py<38]
     - filelock
-    - huggingface_hub >=0.10.0,<1.0
-    - numpy >=1.17
-    - packaging >=20.0
+    - huggingface_hub
+    - numpy
+    - packaging
     - pytorch
-    - pyyaml >=5.1
+    - pyyaml
     - regex !=2019.12.17
     - requests
-    - tokenizers >=0.11.1,!=0.11.3,<0.14
+    - sacremoses
+    - tokenizers >=0.11.1,!=0.11.3
     - tqdm >=4.27
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,6 +11,10 @@ source:
 
 build:
   skip: True  # [py<37]
+  # s390x is missing pyrarrow that datasets depends on
+  skip: True  # [linux and s390x]
+  # At present, there are no 3.11 compatible Pytorch version for win or ppc
+  skip: True  # [py>310 and (pp64le or win)]
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,9 @@ requirements:
     - huggingface_hub >=0.14.1,<1.0
     - numpy
     - packaging
-    - pytorch
+    # TODO: Working around osx bug importing two openmp variants.
+    - pytorch  # [not (osx and x86_64)]
+    - pytorch <1.12,>1.9  # [osx and x86_64]
     - pyyaml
     - regex !=2019.12.17
     - requests

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,8 +11,8 @@ source:
 
 build:
   skip: True  # [py<37]
-  number: 0
-  script: {{ PYTHON }} -m pip install . -vv
+  number: 1
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:
     - transformers-cli=transformers.commands.transformers_cli:main
 
@@ -60,7 +60,6 @@ about:
   license: Apache-2.0
   license_family: Apache
   license_file: LICENSE
-  license_url: https://github.com/huggingface/transformers/blob/main/LICENSE
   summary: State-of-the-art Machine Learning for JAX, PyTorch and TensorFlow
   description: |
     Transformers provides thousands of pretrained models to perform tasks on different modalities such as text, vision, and audio.
@@ -73,7 +72,6 @@ about:
     
     Transformer models can also perform tasks on several modalities combined, such as table question answering, optical character recognition, information extraction from scanned documents, video classification, and visual question answering.
   doc_url: https://huggingface.co/docs/transformers/index
-  doc_source_url: https://github.com/huggingface/transformers/tree/main/docs/source
   dev_url: https://github.com/huggingface/transformers
 
 extra:
@@ -86,3 +84,5 @@ extra:
     - setu4993
     - hadim
     - wietsedv
+  skip-lints:
+    - python_build_tool_in_run

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,8 @@ build:
   # s390x is missing pyrarrow that datasets depends on
   skip: True  # [linux and s390x]
   # At present, there are no 3.11 compatible Pytorch version for win or ppc
-  skip: True  # [py>310 and (pp64le or win)]
+  # There is a bug requiring PyTorch 1.10 on osx-64 which is not available for 3.11 
+  skip: True  # [py>310 and (ppc64le or win or (osx and x86_64))]
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:


### PR DESCRIPTION
License: https://github.com/huggingface/transformers/blob/v4.29.2/LICENSE
Changelog: https://github.com/huggingface/transformers/releases
Requirements: https://github.com/huggingface/transformers/blob/v4.29.2/setup.py

Actions:
1. Skip `py>310 and (ppc64le or win or (osx and x86_64))` because of missing `pytorch`
2. Skip `s390x` because of missing `pyrarrow`
3. Add `--no-deps --no-build-isolation` flags to `script`
4. Update `run` dependencies: update pinnings, fix `openmp` issue on `osx-64`
5. Remove `license_url` and `doc_source_url`