### PR TITLE
[PKG-2629] transformers 4.32.1

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,6 @@
+upload_without_merge: true
+
+upload_channels:
+  - sk_test
+channels:
+  - sk_test

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,6 +1,0 @@
-upload_without_merge: true
-
-upload_channels:
-  - sk_test
-channels:
-  - sk_test

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,8 +13,6 @@ build:
   skip: True  # [py<37]
   # s390x is missing pyrarrow that datasets depends on
   skip: True  # [linux and s390x]
-  # Dropping ppc because of pytorch
-  skip: True  # [linux and ppc64le]
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:
@@ -50,12 +48,10 @@ test:
     - transformers.benchmark
     - transformers.commands
     - transformers.data
-    - transformers.data.datasets
-    - transformers.data.metrics
-    - transformers.data.processors
+    - transformers.kernels
     - transformers.models
     - transformers.pipelines
-    - transformers.sagemaker
+    - transformers.tools
     - transformers.utils
   commands:
     - pip check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "transformers" %}
-{% set version = "4.32.0" %}
+{% set version = "4.32.1" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: ca510f9688d2fe7347abbbfbd13f2f6dcd3c8349870c8d0ed98beed5f579b354
+  sha256: 1edc8ae1de357d97c3d36b04412aa63d55e6fc0c4b39b419a7d380ed947d2252
 
 build:
   skip: True  # [py<37]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,6 +43,8 @@ requirements:
 test:
   requires:
     - pip
+    # to satisfy `transformers-cli --help` because it raises a warning of missing pytorch/tensorflow/flax for models
+    - pytorch
   imports:
     - transformers
     - transformers.benchmark

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "transformers" %}
-{% set version = "4.29.2" %}
+{% set version = "4.32.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,15 +7,14 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: ed9467661f459f1ce49461d83f18f3b36b6a37f306182dc2ba272935f3b93ebb
+  sha256: ca510f9688d2fe7347abbbfbd13f2f6dcd3c8349870c8d0ed98beed5f579b354
 
 build:
   skip: True  # [py<37]
   # s390x is missing pyrarrow that datasets depends on
   skip: True  # [linux and s390x]
-  # At present, there are no 3.11 compatible Pytorch version for win or ppc
-  # There is a bug requiring PyTorch 1.10 on osx-64 which is not available for 3.11 
-  skip: True  # [py>310 and (ppc64le or win or (osx and x86_64))]
+  # Dropping ppc because of pytorch
+  skip: True  # [linux and ppc64le]
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:
@@ -30,20 +29,17 @@ requirements:
   run:
     - python
     # datasets required for transformers-cli.
-    - datasets
-    - importlib-metadata  # [py<38]
+    - datasets !=2.5.0
+    - importlib-metadata
     - filelock
-    - huggingface_hub >=0.14.1,<1.0
-    - numpy
-    - packaging
-    # TODO: Working around osx bug importing two openmp variants.
-    - pytorch             # [not (osx and x86_64)]
-    - pytorch >1.9,<1.12  # [osx and x86_64]
-    - pyyaml
+    - huggingface_hub >=0.15.1,<1.0
+    - numpy >=1.17
+    - packaging >=20.0
+    - pyyaml >=5.1
     - regex !=2019.12.17
     - requests
-    - sacremoses
-    - tokenizers >=0.11.1,!=0.11.3
+    - safetensors >=0.3.1
+    - tokenizers >=0.11.1,!=0.11.3,<0.14
     - tqdm >=4.27
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -43,8 +43,9 @@ requirements:
 test:
   requires:
     - pip
-    # to satisfy `transformers-cli --help` because it raises a warning of missing pytorch/tensorflow/flax for models
-    - pytorch
+    # to satisfy `transformers-cli --help` because it raises a warning of missing pytorch/tensorflow/flax for models.
+    # skip ppc64le because of lack of pytorch
+    - pytorch  # [not (linux and ppc64le)]
   imports:
     - transformers
     - transformers.benchmark


### PR DESCRIPTION
Changelog: https://github.com/huggingface/transformers/releases
License: https://github.com/huggingface/transformers/blob/main/LICENSE
Requirements: https://github.com/huggingface/transformers/blob/v4.32.1/setup.py

Actions:
1. Enable py311 support by removing obsolete skipping logic
2. Update run dependencies and pinnings, also add `safetensors >=0.3.1`, see https://github.com/AnacondaRecipes/safetensors-feedstock/pull/1
3. Add `pytorch  # [not (linux and ppc64le)]` to `test/requires` to satisfy `transformers-cli --help` command
4. Update test/imports as the package already doesn't rely on `pytorch` directly