### PR TITLE
Downgrade to 4.31.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "transformers" %}
-{% set version = "4.32.1" %}
+{% set version = "4.31.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 1edc8ae1de357d97c3d36b04412aa63d55e6fc0c4b39b419a7d380ed947d2252
+  sha256: 4302fba920a1c24d3a429a29efff6a63eac03f3f3cf55b55927fc795d01cb273
 
 build:
   skip: True  # [py<37]
@@ -30,7 +30,7 @@ requirements:
     - datasets !=2.5.0
     - importlib-metadata
     - filelock
-    - huggingface_hub >=0.15.1,<1.0
+    - huggingface_hub >=0.14.1,<1.0
     - numpy >=1.17
     - packaging >=20.0
     - pyyaml >=5.1


### PR DESCRIPTION
Release 4.31.0 that will be required for autogluon 1.0.0.

Upstream: https://github.com/huggingface/transformers/tree/v4.31.0

Channel: defaults

https://anaconda.atlassian.net/browse/PKG-3574