### PR TITLE
transformers 4.37.2: Rebuild for py312

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:
-  - https://staging.continuum.io/prefect/fs/safetensors-feedstock/pr4/f9b031b

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+  - https://staging.continuum.io/prefect/fs/safetensors-feedstock/pr4/f9b031b

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ build:
   skip: True  # [py<38]
   # s390x is missing pyrarrow that datasets depends on
   skip: True  # [linux and s390x]
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:
     - transformers-cli=transformers.commands.transformers_cli:main
@@ -74,7 +74,7 @@ about:
     - 📝 Text, for tasks like text classification, information extraction, question answering, summarization, translation, text generation, in over 100 languages.
     - 🖼️ Images, for tasks like image classification, object detection, and segmentation.
     - 🗣️ Audio, for tasks like speech recognition and audio classification.
-    
+
     Transformer models can also perform tasks on several modalities combined, such as table question answering, optical character recognition, information extraction from scanned documents, video classification, and visual question answering.
   doc_url: https://huggingface.co/docs/transformers/index
   dev_url: https://github.com/huggingface/transformers


### PR DESCRIPTION
Missing py312:

```
transformers                  4.37.2 py310hca03da5_0  pkgs/main
transformers                  4.37.2 py311hca03da5_0  pkgs/main
transformers                  4.37.2  py38hca03da5_0  pkgs/main
transformers                  4.37.2  py39hca03da5_0  pkgs/main
```