### PR TITLE
PKG-5563: Update transformers to v4.44.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,6 +39,8 @@ requirements:
     - safetensors >=0.4.1
     - tokenizers >=0.19,<0.20
     - tqdm >=4.27
+  run_constrained:
+    - blas * openblas     # [osx and x86_64]
 
 test:
   source_files:
@@ -56,7 +58,6 @@ test:
     - pip
     # to satisfy `transformers-cli --help` because it raises a warning of missing pytorch/tensorflow/flax for models.
     - pytorch >=2
-    - blas * openblas     # [osx and x86_64]
     - bs4
     - nltk
     - parameterized

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,7 +55,8 @@ test:
   requires:
     - pip
     # to satisfy `transformers-cli --help` because it raises a warning of missing pytorch/tensorflow/flax for models.
-    - pytorch
+    - pytorch >=2
+    - blas * openblas     # [osx and x86_64]
     - bs4
     - nltk
     - parameterized

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,13 +1,13 @@
 {% set name = "transformers" %}
-{% set version = "4.41.2" %}
+{% set version = "4.44.1" %}
 
 package:
   name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://github.com/huggingface/transformers/archive/refs/tags/v4.41.2.tar.gz
-  sha256: a1dea0cae3e952f5e14b04a31c7ae173eb5c2f7149349e73405612be494a971c
+  url: https://github.com/huggingface/transformers/archive/refs/tags/v{{ version }}.tar.gz
+  sha256: b589796ff2c85953664e91a41c4959fdad4734d2aae6f88e02a246a73086f919
 
 build:
   skip: True  # [py<38]


### PR DESCRIPTION
transformers 4.44.1 

**Destination channel:** defaults

### Links

- [PKG-5563](https://anaconda.atlassian.net/browse/PKG-5563) 
- [Upstream repository](https://github.com/huggingface/transformers)
- [Upstream changelog/diff](https://github.com/huggingface/transformers/compare/v4.44.0...v4.44.1)

### Explanation of changes:

- Update transformers to v4.44.1


[PKG-5563]: https://anaconda.atlassian.net/browse/PKG-5563?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ