### PR TITLE
tranformers 4.40.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,8 +11,6 @@ source:
 
 build:
   skip: True  # [py<38]
-  # s390x is missing pyrarrow that datasets depends on
-  skip: True  # [linux and s390x]
   number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:
@@ -36,6 +34,47 @@ requirements:
     - safetensors >=0.4.1
     - tokenizers >=0.19,<0.20
     - tqdm >=4.27
+  run_constrained:
+    # all extra dependencies except 'testing'
+    - pillow >=10.0.1,<=15.0
+    - accelerate >=0.21.0
+    - av ==9.2.0
+    - codecarbon ==1.2.0
+    - cookiecutter ==1.7.3
+    - datasets !=2.5.0
+    - decord ==0.6.0
+    - deepspeed >=0.9.3
+    - dill <0.3.5
+    - evaluate >=0.2.0
+    - flax >=0.4.1,<=0.7.0
+    - fsspec <2023.10.0
+    - fugashi >=1.0
+    - GitPython <3.1.19
+    - hf-doc-builder >=0.3.0
+    - ipadic >=1.0.0,<2.0
+    - isort >=5.5.4
+    - jax >=0.4.1,<=0.4.13
+    - jaxlib >=0.4.1,<=0.4.13
+    - keras <2.16
+    - keras-nlp >=0.3.1
+    - natten >=0.14.6,<0.15.0
+    - onnxruntime-tools >=1.4.2
+    - onnxruntime >=1.4.0
+    - optax >=0.0.8,<=0.1.4
+    - ray-tune >=2.7.0
+    - rhoknp >=1.1.0,<1.3.1
+    - ruff ==0.1.5
+    - sagemaker >=2.31.0
+    - sentencepiece >=0.1.91,!=0.1.92
+    - sudachipy >=0.6.6
+    - sudachidict_core >=20220729
+    - tensorflow-cpu >=2.6,<2.16
+    - tensorflow >=2.6,<2.16
+    - tensorflow-text <2.16
+    - pyctcdecode >=0.4.0
+    - unidic >=1.0.2
+    - unidic_lite >=1.0.7
+    - urllib3 <2.0.0
 
 test:
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "transformers" %}
-{% set version = "4.37.2" %}
+{% set version = "4.40.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,13 +7,13 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: f307082ae5d528b8480611a4879a4a11651012d0e9aaea3f6cf17219ffd95542
+  sha256: 657b6054a2097671398d976ad46e60836e7e15f9ea9551631a96e33cb9240649
 
 build:
   skip: True  # [py<38]
   # s390x is missing pyrarrow that datasets depends on
   skip: True  # [linux and s390x]
-  number: 1
+  number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:
     - transformers-cli=transformers.commands.transformers_cli:main
@@ -26,9 +26,6 @@ requirements:
     - wheel
   run:
     - python
-    # datasets required for transformers-cli.
-    #- datasets !=2.5.0
-    - importlib-metadata
     - filelock
     - huggingface_hub >=0.19.3,<1
     - numpy >=1.17
@@ -37,7 +34,7 @@ requirements:
     - regex !=2019.12.17
     - requests
     - safetensors >=0.4.1
-    - tokenizers >=0.14,<0.19
+    - tokenizers >=0.19,<0.20
     - tqdm >=4.27
 
 test:
@@ -51,9 +48,13 @@ test:
     - transformers.benchmark
     - transformers.commands
     - transformers.data
-    - transformers.kernels
+    - transformers.generation
+    - transformers.integrations
     - transformers.models
+    - transformers.onnx
     - transformers.pipelines
+    - transformers.quantizers
+    - transformers.sagemaker
     - transformers.tools
     - transformers.utils
   commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,8 +44,6 @@ requirements:
     - datasets !=2.5.0
     - decord ==0.6.0
     - deepspeed >=0.9.3
-    - dill <0.3.5
-    - evaluate >=0.2.0
     - flax >=0.4.1,<=0.7.0
     - fsspec <2023.10.0
     - fugashi >=1.0


### PR DESCRIPTION
tranformers 4.40.2

**Destination channel:** defaults

### Links

- [PKG-6296]
- [Upstream repository](https://github.com/huggingface/transformers/tree/v4.40.2)

### Explanation of changes:

- Build 4.40.2 for `autogluon`


[PKG-6296]: https://anaconda.atlassian.net/browse/PKG-6296?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ