### PR TITLE
bump build number and min python version

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -209,5 +209,4 @@ extra:
     - setu4993
     - hadim
     - wietsedv
-  skip-lints:
-    - python_build_tool_in_run
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 3f637746c5dde387ae418d23741bdcee94aa6607c9ea256e708d5a0e811ef893
 
 build:
-  skip: True  # [py<310]
+  skip: True  # [py != 314]
   number: 1
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,8 +10,8 @@ source:
   sha256: 3f637746c5dde387ae418d23741bdcee94aa6607c9ea256e708d5a0e811ef893
 
 build:
-  skip: True  # [py<39]
-  number: 0
+  skip: True  # [py<310]
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:
     - transformers-cli=transformers.commands.transformers_cli:main


### PR DESCRIPTION
Needed for https://github.com/AnacondaRecipes/spacy-transformers-feedstock/pull/11

purpose: rebuild for py3.14