### PR TITLE
update to 5.9.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -106,6 +106,10 @@ test:
     - pip
     # to satisfy `transformers --help` because it raises a warning of missing pytorch/tensorflow for models.
     - pytorch
+    # 5.9.0 tests load vision models (aria) and the Trainer, needing torchvision/accelerate
+    # (both optional for end users, so kept in run_constrained)
+    - torchvision
+    - accelerate >=1.1.0
     # PBP is using the GPU version for some reason:
     - bs4
     # NLTK recent 3.9 release breaks FastSpeechConformer2 tests,

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "transformers" %}
-{% set version = "5.3.0" %}
+{% set version = "5.9.0" %}
 
 package:
   name: {{ name }}
@@ -7,10 +7,10 @@ package:
 
 source:
   url: https://github.com/huggingface/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
-  sha256: 33171c5a932471a56b1e2210e0cba443732d195d03151ce1e538404ad9806052
+  sha256: aea88fd01ea5344d4e1a8692ee029258de8040381827211a306c3e2be3ace4ac
 
 build:
-  number: 1
+  number: 0
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   entry_points:
     - transformers=transformers.cli.transformers:main
@@ -24,11 +24,11 @@ requirements:
     - wheel
   run:
     - python
-    - huggingface_hub >=1.3.0,<2.0
+    - huggingface_hub >=1.5.0,<2.0
     - numpy >=1.17
     - packaging >=20.0
     - pyyaml >=5.1
-    - regex !=2019.12.17
+    - regex >=2025.10.22
     - safetensors >=0.4.3
     - tokenizers >=0.22.0,<=0.23.0
     - tqdm >=4.27
@@ -40,7 +40,7 @@ requirements:
     # torch, accelerate, deepspeed, serving:
     - accelerate >=1.1.0
     # kernels, integrations:
-    - kernels >=0.10.2,<0.11
+    - kernels >=0.12.0,<0.13
     # integrations, codecarbon:
     - codecarbon >=2.8.1
     # integrations, ray:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -56,7 +56,7 @@ requirements:
     # sentencepiece:
     - sentencepiece >=0.1.91,!=0.1.92
     # mistral-common:
-    - mistral-common >=1.8.8  # [py<314]
+    - mistral-common >=1.10.0  # [py<314]
     # chat_template:
     - jinja2 >=3.1.0
     - jmespath >=1.0.1
@@ -265,5 +265,3 @@ extra:
     - setu4993
     - hadim
     - wietsedv
-  skip-lints:
-    - python_build_tool_in_run

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -195,9 +195,9 @@ test:
     {% set skip_tests = skip_tests + " or return_dict_in_generate" %}
     {% set skip_tests = skip_tests + " or stop_sequence_stopping_criteria" %}
 
-    # bf16/fp16 pipeline scores differ slightly on ARM (linux-aarch64 + osx-arm64)
-    {% set skip_tests = skip_tests + " or torch_bfloat16_pipeline" %}  # [arm64]
-    {% set skip_tests = skip_tests + " or accepts_torch_fp16" %}  # [arm64]
+    # bf16/fp16 pipeline scores differ slightly on linux-aarch64 (osx-arm64 handled above)
+    {% set skip_tests = skip_tests + " or torch_bfloat16_pipeline" %}  # [aarch64]
+    {% set skip_tests = skip_tests + " or accepts_torch_fp16" %}  # [aarch64]
 
     # Require Mac OS 14
     {% set skip_tests = skip_tests + " or return_timestamps_in_init" %}  # [osx and arm64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -106,8 +106,10 @@ test:
     - pip
     # to satisfy `transformers --help` because it raises a warning of missing pytorch/tensorflow for models.
     - pytorch
-    # 5.9.0 tests load vision models (aria) and the Trainer, needing torchvision/accelerate
-    # (both optional for end users, so kept in run_constrained)
+    # 5.9.0 tests load vision models (aria) + the Trainer, so the test env needs
+    # torchvision and accelerate. Both are optional for end users: accelerate is bounded
+    # in run_constrained above; torchvision's upstream `vision` extra is unversioned, so a
+    # run_constrained entry would be a no-op — it stays test-only.
     - torchvision
     - accelerate >=1.1.0
     # PBP is using the GPU version for some reason:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -163,6 +163,8 @@ test:
     # [Windows] Upstream bug where non-CUDA machines (CI) fail to correctly skip CUDA test on Windows
     # fatal exception: access violation
     {% set ignore_tests = ignore_tests + " --ignore=tests/test_executorch.py" %}  # [win]
+    # serving route tests use asyncio.get_event_loop(), removed in Python 3.14
+    {% set ignore_tests = ignore_tests + " --ignore=tests/cli/test_serve.py" %}  # [py>=314]
     #     mode: ValidationMode = ValidationMode.test,
     # E   NameError: name 'ValidationMode' is not defined
     {% set ignore_tests = ignore_tests + " --ignore=tests/test_tokenization_mistral_common.py" %}
@@ -192,6 +194,10 @@ test:
     {% set skip_tests = skip_tests + " or torch_float16_pipeline" %}
     {% set skip_tests = skip_tests + " or return_dict_in_generate" %}
     {% set skip_tests = skip_tests + " or stop_sequence_stopping_criteria" %}
+
+    # bf16/fp16 pipeline scores differ slightly on ARM (linux-aarch64 + osx-arm64)
+    {% set skip_tests = skip_tests + " or torch_bfloat16_pipeline" %}  # [arm64]
+    {% set skip_tests = skip_tests + " or accepts_torch_fp16" %}  # [arm64]
 
     # Require Mac OS 14
     {% set skip_tests = skip_tests + " or return_timestamps_in_init" %}  # [osx and arm64]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -122,6 +122,9 @@ test:
     - fastapi
     - uvicorn
     - pytest >=7.2.0,<9.0.0
+    # 5.9.0's NetworkDebugPlugin registers the xdist hook pytest_configure_node;
+    # without pytest-xdist installed, pytest rejects it (PluginValidationError) at collection
+    - pytest-xdist
     - sentencepiece >=0.1.91,!=0.1.92
     - rich
     - datasets

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -114,9 +114,13 @@ test:
     - parameterized
     - psutil
     - pydantic >=2
-    # 5.9.0 serving CLI eager-imports openai's CompletionCreateParamsStreaming;
-    # `transformers --help` loads it, so the test env needs openai (kept optional in run_constrained)
+    # 5.9.0's serving CLI defines a class from openai unconditionally, but guards the
+    # import behind is_serve_available() = pydantic AND fastapi AND uvicorn AND openai.
+    # `transformers --help` loads that module, so all four must be in the test env or it
+    # NameErrors. They stay optional (run_constrained) for end users.
     - openai >=1.98.0
+    - fastapi
+    - uvicorn
     - pytest >=7.2.0,<9.0.0
     - sentencepiece >=0.1.91,!=0.1.92
     - rich

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -114,6 +114,9 @@ test:
     - parameterized
     - psutil
     - pydantic >=2
+    # 5.9.0 serving CLI eager-imports openai's CompletionCreateParamsStreaming;
+    # `transformers --help` loads it, so the test env needs openai (kept optional in run_constrained)
+    - openai >=1.98.0
     - pytest >=7.2.0,<9.0.0
     - sentencepiece >=0.1.91,!=0.1.92
     - rich


### PR DESCRIPTION
transformers 5.9.0

**Destination channel:** defaults

### Links
- [Upstream source (v5.9.0)](https://github.com/huggingface/transformers/tree/v5.9.0)
- [PKG-15660](https://anaconda.atlassian.net/browse/PKG-15660)
- [PyPI](https://pypi.org/project/transformers/5.9.0/)
- [GitHub v5.9.0](https://github.com/huggingface/transformers/releases/tag/v5.9.0)

### Explanation of changes
- Update transformers 5.3.0 → 5.9.0.

**Why 5.9.0 specifically (not the latest 5.12.1):** axolotl 0.17.0 — the current release and the target of epic PKG-14882 — hard-pins `transformers==5.9.0` (exact),

[PKG-15660]: https://anaconda.atlassian.net/browse/PKG-15660

